### PR TITLE
added place and date info for the KDD2025 conference which are mandatory 

### DIFF
--- a/src/data/conferences.yml
+++ b/src/data/conferences.yml
@@ -436,6 +436,8 @@
   start: '2025-08-03'
   end: '2025-08-07'
   timezone: AoE
+  place: Toronto, ON, Canada
+  date: August 3 - August 7, 2025
   tags:
   - data-mining
   - machine-learning


### PR DESCRIPTION
added place and date info for the KDD2025 conference. Place and date are mandatory fields for any conference according to the contribution policies.

without that info, the conference card looks like below.

<img width="419" alt="image" src="https://github.com/user-attachments/assets/cdfec718-1056-4293-85da-a3ef5b51429a" />
