### PR TITLE
calculateTimeLeft() based on local time

### DIFF
--- a/src/components/ConferenceDialog.tsx
+++ b/src/components/ConferenceDialog.tsx
@@ -25,6 +25,7 @@ interface ConferenceDialogProps {
 
 const ConferenceDialog = ({ conference, open, onOpenChange }: ConferenceDialogProps) => {
   const deadlineDate = conference.deadline && conference.deadline !== 'TBD' ? parseISO(conference.deadline) : null;
+  const deadlineTimeZone = conference.timezone && conference.timezone !== 'TBD' ? conference.timezone : null;
   const [countdown, setCountdown] = useState<string>('');
 
   useEffect(() => {
@@ -35,8 +36,13 @@ const ConferenceDialog = ({ conference, open, onOpenChange }: ConferenceDialogPr
       }
 
       const now = new Date().getTime();
-      const difference = deadlineDate.getTime() - now;
+      var difference = deadlineDate.getTime() - now;
 
+      if (deadlineTimeZone){
+        // TODO: Check the validity of the deadlineTimeZone
+        const localDeadlineDate = new Date(`${deadlineDate} ${deadlineTimeZone}`);
+        difference = localDeadlineDate.getTime() - now;
+      }
       if (difference <= 0) {
         setCountdown('Deadline passed');
         return;


### PR DESCRIPTION
Currently, the difference "TimeLeft" is computed using a different timezone than the local timezone, which may cause wrong information. 

```
const now = new Date().getTime();
difference = deadlineDate.getTime() - now;
```

I am not sure if this is the best solution to solve it, I am naive in JS, but I think this should work.

I did not know how to check the validity of the timezone string, there must be a function from some package, so I kept it as a todo.

Thank you for reviving aideadlines with a very nice interface and utilities.
