### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@bee87b3258c251f9279e5371b0cc3660f37f3f77  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/update-conferences.yml
+++ b/.github/workflows/update-conferences.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: '3.x'
     
@@ -36,7 +36,7 @@ jobs:
     
     - name: Create Pull Request
       if: steps.git-check.outputs.changes == 'true'
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5
       with:
         commit-message: 'chore: update conference data from ccfddl'
         title: 'Update conference data from ccfddl'


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `claude-code-review.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `claude-code-review.yml` | `anthropics/claude-code-action` | `v1` | `v1` | `bee87b3258c2…` |
| `update-conferences.yml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500…` |
| `update-conferences.yml` | `actions/setup-python` | `v4` | `v4` | `7f4fc3e22c37…` |
| `update-conferences.yml` | `peter-evans/create-pull-request` | `v5` | `v5` | `4e1beaa7521e…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#61