### PR TITLE
Add EUVIP 2026 conference

### DIFF
--- a/src/data/conferences/euvip.yml
+++ b/src/data/conferences/euvip.yml
@@ -1,0 +1,25 @@
+- title: EUVIP
+  year: 2026
+  id: euvip26
+  full_name: European Conference on Visual Information Processing
+  link: https://euvip2026.github.io/
+  deadlines:
+    - type: submission
+      label: Paper submission deadline
+      date: "2026-05-21 23:59:59"
+      timezone: UTC+02
+  timezone: Europe/Luxembourg
+  city: Luxembourg
+  country: Luxembourg
+  venue: Parc Hotel Alvisse, 120 Rte d'Echternach, 1453 Dommeldange, Luxembourg
+  date: September 28 - October 1, 2026
+  start: 2026-09-28
+  end: 2026-10-01
+  tags:
+    - computer vision
+    - image processing
+    - signal processing
+    - machine learning
+    - deep learning
+    - visual information processing
+  note: To check other calls (e.g., Tutorials, Special Sessions, etc.), please visit https://euvip2026.github.io/calls/


### PR DESCRIPTION
## Which conference does this PR update?

- EUVIP 2026

## Related URL

- Conference website: https://euvip2026.github.io/
- DBLP: https://dblp.org/db/conf/euvip
- LinkedIn page: https://www.linkedin.com/company/euvip-2026/
- X profile: https://x.com/Euvip2026
- Bluesky profile: https://bsky.app/profile/euvip2026.bsky.social
