### PR TITLE
Update EUVIP 2026 deadline.

### DIFF
--- a/src/data/conferences/euvip.yml
+++ b/src/data/conferences/euvip.yml
@@ -6,7 +6,7 @@
   deadlines:
     - type: submission
       label: Paper submission deadline
-      date: "2026-05-21 23:59:59"
+      date: "2026-06-05 23:59:59"
       timezone: UTC+02
   timezone: Europe/Luxembourg
   city: Luxembourg


### PR DESCRIPTION
## Which conference does this PR update?

- EUVIP 2026

## Related URL

- Conference website: https://euvip2026.github.io/
- DBLP: https://dblp.org/db/conf/euvip
- LinkedIn page: https://www.linkedin.com/company/euvip-2026/
- X profile: https://x.com/Euvip2026
- Bluesky profile: https://bsky.app/profile/euvip2026.bsky.social
