### PR TITLE
Add 3DV 2027

### DIFF
--- a/src/data/conferences/3dv.yml
+++ b/src/data/conferences/3dv.yml
@@ -1,0 +1,31 @@
+- title: 3DV
+  year: 2027
+  id: 3dv27
+  full_name: International Conference on 3D Vision
+  link: https://3dvconf.github.io/2027/
+  deadlines:
+  - type: submission
+    label: Paper Submission Deadline
+    date: '2026-08-28 11:00:00'
+    timezone: UTC-7
+  - type: supplementary
+    label: Supplementary Material Deadline
+    date: '2026-09-02 11:00:00'
+    timezone: UTC-7
+  - type: notification
+    label: Preliminary Notification
+    date: '2026-10-27 23:59:59'
+    timezone: UTC-7
+  - type: notification
+    label: Final Notification
+    date: '2026-12-02 23:59:59'
+    timezone: UTC-7
+  date: April 6-9, 2027
+  start: 2027-04-06
+  end: 2027-04-09
+  city: Thessaloniki
+  country: Greece
+  venue: Thessaloniki, Greece
+  tags:
+  - computer-vision
+  rankings: 'CCF: C, CORE: N, THCPL: N'

--- a/src/data/conferences/3dv.yml
+++ b/src/data/conferences/3dv.yml
@@ -27,5 +27,6 @@
   country: Greece
   venue: Thessaloniki, Greece
   tags:
+  - machine-learning
   - computer-vision
   rankings: 'CCF: C, CORE: N, THCPL: N'


### PR DESCRIPTION
Adds 3DV (International Conference on 3D Vision) 2027, per https://3dvconf.github.io/2027/dates/

- Paper submission Aug 28, 2026 and supplementary Sep 2, 2026, both 11:00 am PDT (as stated on the site)
- Preliminary / final notification: Oct 27 / Dec 2, 2026
- Conference: April 6-9, 2027, Thessaloniki, Greece