### PR TITLE
Update Eurographics, WSDM, and WACV 2027

### DIFF
--- a/src/data/conferences/eurographics.yml
+++ b/src/data/conferences/eurographics.yml
@@ -73,10 +73,46 @@
   year: 2027
   id: eurographics27
   full_name: The 48th Annual Conference of the European Association for Computer Graphics
-  link: https://www.eg.org/wp/eg-events/eurographics-annual-conference/
-  city: Pisa
+  link: https://eg2027.isti.cnr.it/
+  deadlines:
+    - type: abstract
+      label: Abstract and submission form deadline
+      date: '2026-09-25 23:59:59'
+      timezone: UTC
+    - type: paper
+      label: Full paper submission deadline
+      date: '2026-10-01 23:59:59'
+      timezone: UTC
+    - type: review_release
+      label: Reviews released
+      date: '2026-11-23 23:59:59'
+      timezone: UTC
+    - type: rebuttal
+      label: Rebuttal due
+      date: '2026-11-30 23:59:59'
+      timezone: UTC
+    - type: notification
+      label: Conditional acceptance or rejection notification
+      date: '2026-12-18 23:59:59'
+      timezone: UTC
+    - type: camera_ready
+      label: Revised version deadline
+      date: '2027-01-26 23:59:59'
+      timezone: UTC
+    - type: notification
+      label: Final notification
+      date: '2027-02-09 23:59:59'
+      timezone: UTC
+    - type: camera_ready
+      label: Camera-ready version due
+      date: '2027-02-23 23:59:59'
+      timezone: UTC
+  city: Lucca
   country: Italy
-  venue: Pisa, Italy
+  venue: IMT Campus, Lucca, Italy
+  date: May 10 - 14, 2027
+  start: 2027-05-10
+  end: 2027-05-14
   tags:
   - computer-graphics
   era_rating: a

--- a/src/data/conferences/wacv.yml
+++ b/src/data/conferences/wacv.yml
@@ -88,11 +88,15 @@
   deadlines:
   - type: registration
     label: Round 1 Paper Registration
-    date: '2026-06-18 23:59:59'
+    date: '2026-06-19 23:59:59'
     timezone: AoE
   - type: submission
     label: Round 1 Paper Submission
-    date: '2026-06-25 23:59:59'
+    date: '2026-06-26 23:59:59'
+    timezone: AoE
+  - type: supplementary
+    label: Round 1 Supplementary Material
+    date: '2026-06-28 23:59:59'
     timezone: AoE
   - type: review_release
     label: Round 1 Reviews and Decisions To Authors

--- a/src/data/conferences/wsdm.yml
+++ b/src/data/conferences/wsdm.yml
@@ -63,3 +63,41 @@
   - data-mining
   era_rating: b
   rankings: 'CCF: B, CORE: A*, THCPL: B'
+
+- title: WSDM
+  year: 2027
+  id: wsdm27
+  full_name: ACM International Conference on Web Search and Data Mining
+  link: https://www.wsdm-conference.org/2027/
+  deadlines:
+    - type: abstract
+      label: Abstract submission (full papers)
+      date: '2026-08-17 23:59:59'
+      timezone: AoE
+    - type: paper
+      label: Paper submission (full papers)
+      date: '2026-08-24 23:59:59'
+      timezone: AoE
+    - type: notification
+      label: Author notification (full papers)
+      date: '2026-11-02 23:59:59'
+      timezone: AoE
+    - type: paper
+      label: Paper submission (short papers)
+      date: '2026-11-17 23:59:59'
+      timezone: AoE
+    - type: notification
+      label: Author notification (short papers)
+      date: '2026-12-18 23:59:59'
+      timezone: AoE
+  city: Hong Kong
+  country: Hong Kong
+  venue: Cordis, Hong Kong
+  date: February 15-19, 2027
+  start: 2027-02-15
+  end: 2027-02-19
+  tags:
+  - web-search
+  - data-mining
+  era_rating: b
+  rankings: 'CCF: B, CORE: A*, THCPL: B'


### PR DESCRIPTION
## Summary of This PR

Completes the Eurographics 2027 schedule and venue, adds WSDM 2027, and corrects WACV 2027 Round 1 dates. The conference information was checked against the official pages.

Checks: `npm run validate`, `npm run build`

Sources: [Eurographics 2027](https://eg2027.isti.cnr.it/call-for-papers/), [WSDM 2027](https://www.wsdm-conference.org/2027/), [WSDM short papers](https://www.wsdm-conference.org/2027/cfsp.html), [WACV 2027](https://wacv.thecvf.com/Conferences/2027/Dates)